### PR TITLE
Update main.css to display logout link in dropdown

### DIFF
--- a/main.css
+++ b/main.css
@@ -29,3 +29,7 @@ nav a.brand:after {
 * {
   border-radius: 5px !important;
 }
+
+.dropdown-item {
+   color:white !important; 
+}


### PR DESCRIPTION
Logout link was not showing in dark mode because it was the input of a form. 

My initial thought was to use `form *` as the selector but in case of adding forms in the future, it seemed `.dropdown-item` was safest.